### PR TITLE
updating to remove links to gitter as not maintained

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # Welcome to the Q# Community!
-
-[![Gitter](https://badges.gitter.im/qsharp-community/community.svg)](https://gitter.im/qsharp-community/community?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
+[![Slack](https://img.shields.io/badge/slack-QSharpCommunity-blue.svg?logo=slack)](https://join.slack.com/t/qsharp-community/shared_invite/zt-fnsl4u42-u21wdJRzlLF9oAqYTDDtwA)
 
 This group collects + maintains projects related to the [Q# programming language](https://docs.microsoft.com/quantum) by a community of folks who are excited about quantum programming! 😊
 

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -6,8 +6,7 @@ permalink: /
 toc: false
 ---
 <h1>Welcome!</h1>
-<a href="https://gitter.im/qsharp-community/community?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge"><img src="https://badges.gitter.im/qsharp-community/community.svg" title="gitter-badge" /></a>
-<a href="https://join.slack.com/t/qsharp-community/shared_invite/zt-fnsl4u42-u21wdJRzlLF9oAqYTDDtwA"><img src="https://img.shields.io/badge/chat-on%20slack-blue" title="slack-badge" /></a>
+<a href="https://join.slack.com/t/qsharp-community/shared_invite/zt-fnsl4u42-u21wdJRzlLF9oAqYTDDtwA"><img src="https://img.shields.io/badge/slack-QSharpCommunity-blue.svg?logo=slack" title="slack-badge" /></a>
 <img alt="GitHub" src="https://img.shields.io/github/license/qsharp-community/qsharp-community.github.io">
 <br><br>
 This group collects + maintains projects related to the Q# programming language by a community of folks who are excited about quantum programming! 😊

--- a/_pages/CONTRIBUTING.md
+++ b/_pages/CONTRIBUTING.md
@@ -32,7 +32,7 @@ The community generally suggests MIT licence, as most open source .NET projects 
 ## Reporting issues and suggesting new features
 
 If something about one of the community projects is not working properly, please file an issue of the corresponding repository.
-If you have ideas for new features of the community throw them up on the [Gitter](https://gitter.im/qsharp-community/community) and maintainers can then create [projects](https://github.com/qsharp-community/qsharp-community.github.io/projects) on this repo to track progress and discussions.
+If you have ideas for new features of the community throw them up on the [Slack](https://join.slack.com/t/qsharp-community/shared_invite/zt-fnsl4u42-u21wdJRzlLF9oAqYTDDtwA) and maintainers can then create [projects](https://github.com/qsharp-community/qsharp-community.github.io/projects) on this repo to track progress and discussions.
 Remember that all community interactions must abide by the [Code of Conduct](CODE_OF_CONDUCT.md).
 
 ## Finding issues you can help with

--- a/_pages/about.md
+++ b/_pages/about.md
@@ -13,7 +13,7 @@ The types of content hosted here are (but are not limited to):
 
 If you want to learn more about the process of adding a project to [qsharp-community](https://qsharp.community), please see our [community contribution guide](CONTRIBUTING.md).
 
-We have a community [Gitter](https://gitter.im/qsharp-community/community?utm_source=share-link&utm_medium=link&utm_campaign=share-link) for quick questions and minimal login and a [Slack](https://join.slack.com/t/qsharp-community/shared_invite/zt-fnsl4u42-u21wdJRzlLF9oAqYTDDtwA) for more detailed discussions, so please use these channels to ask the community!
+We have a community [Slack](https://join.slack.com/t/qsharp-community/shared_invite/zt-fnsl4u42-u21wdJRzlLF9oAqYTDDtwA) for questions and detailed discussions, so please use these channels to ask the community!
 They are both great if you have a question about Q# or the QDK, want us to cross-promote or host a blog post, or want to share a cool project you are working on!
 
 > All activities in our community are governed by a [code of conduct](CODE_OF_CONDUCT.md), please email [info@quantum.community](mailto:info@quantum.community) if you have any questions or need to report something.

--- a/_posts/2019-05-25-welcome-to-the-community.md
+++ b/_posts/2019-05-25-welcome-to-the-community.md
@@ -14,7 +14,7 @@ Being this is a community project, we get to decide what we want to host here!
 An initial proposal could be to use this blog to highlight the _community_, by having posts about projects contributed here, or about things folks are doing with Q# elsewhere.
 The posts here need not be exclusive, they could easily be cross-posted to other blog sites as well.
 
->If you have any ideas for a post or would like to volunteer to contribute on, either make a [pull request](https://github.com/qsharp-community/qsharp-community.github.io/pulls) or hop on the [Gitter](https://gitter.im/qsharp-community/community) and let us know!
+>If you have any ideas for a post or would like to volunteer to contribute on, either make a [pull request](https://github.com/qsharp-community/qsharp-community.github.io/pulls) or hop on the [Slack](https://join.slack.com/t/qsharp-community/shared_invite/zt-fnsl4u42-u21wdJRzlLF9oAqYTDDtwA) and let us know!
 
 You can find some templates for posts from the website theme we are using [here](https://github.com/mmistakes/mm-github-pages-starter).
 

--- a/_posts/2020-06-01-call-for-contributions.md
+++ b/_posts/2020-06-01-call-for-contributions.md
@@ -14,9 +14,9 @@ There has been a lot of exciting developments in the Q# community recently, from
 We here at the community have been working hard to curate more community projects, posts, and Q# content, like our new [qRAM library](https://github.com/qsharp-community/qram) or [Q# live coding on twitch](https://www.twitch.tv/crazy4pi314)!
 We are super excited to highlight some of the amazing open source community projects and content that are making the Q# and quantum development community better.
 
-If you would like to contribute a blog post, host your project as a part of the community, or have any ideas for a project you would like to see, either make a [pull request](https://github.com/qsharp-community/qsharp-community.github.io/pulls) or hop on the [Gitter](https://gitter.im/qsharp-community/community) and let us know!
+If you would like to contribute a blog post, host your project as a part of the community, or have any ideas for a project you would like to see, either make a [pull request](https://github.com/qsharp-community/qsharp-community.github.io/pulls) or hop on the [Slack](https://join.slack.com/t/qsharp-community/shared_invite/zt-fnsl4u42-u21wdJRzlLF9oAqYTDDtwA) and let us know!
 
-> Never made a pull request before? Not sure how to use our website template? We can help! Just message us on the [Gitter](https://gitter.im/qsharp-community/community) or send an email to [info@qsharp.community](mailto:info@qsharp.community)💖
+> Never made a pull request before? Not sure how to use our website template? We can help! Just message us on the [Slack](https://join.slack.com/t/qsharp-community/shared_invite/zt-fnsl4u42-u21wdJRzlLF9oAqYTDDtwA) or send an email to [info@qsharp.community](mailto:info@qsharp.community)💖
 
 Thanks, and we are excited to see how this community grows!
 


### PR DESCRIPTION
Realized we still had links to the gitter which I have been trying to migrate to slack so there isn't two places to check for stuff :)